### PR TITLE
proper fallback on invalid json

### DIFF
--- a/src/pyshark/tshark/output_parser/tshark_ek.py
+++ b/src/pyshark/tshark/output_parser/tshark_ek.py
@@ -1,4 +1,5 @@
 import orjson
+import json
 import os
 
 from pyshark.tshark.output_parser.base_parser import BaseTsharkOutputParser
@@ -33,8 +34,9 @@ def packet_from_ek_packet(json_pkt):
         pkt_dict = orjson.loads(json_pkt)
     except orjson.JSONDecodeError:
         # This usually results from incorrect dissection of the packet by tshark, which might
-        # cause invalid characters to be inserted into the JSON.
-        pkt_dict = orjson.loads(json_pkt.decode('utf-8', errors="replace"))
+        # cause invalid characters or control charactersto be inserted into the JSON. 
+        # Fallback to the slower json.loads with strict=False to handle the invalid characters.
+        pkt_dict = json.loads(json_pkt.decode('utf-8', errors='replace'), strict=False)
 
     # We use the frame dict here and not the object access because it's faster.
     layers = pkt_dict['layers']


### PR DESCRIPTION
TShark doesn't control how it's dissectors are implemented and what they output. There was already a fallback to invalid utf-8 characters (error="replace"), however it didn't cover control characters. orjson doesn't support control characters so we have to fallback to the slower stdlib json with strict=False.